### PR TITLE
[Python 3.10 support] Change to winsdk as Microsoft has stopped updating winrt (for now?)

### DIFF
--- a/bezos.py
+++ b/bezos.py
@@ -9,7 +9,7 @@ import time
 from pypresence import Presence
 import re
 
-from winrt.windows.media.control import GlobalSystemMediaTransportControlsSessionManager as MediaManager
+from winsdk.windows.media.control import GlobalSystemMediaTransportControlsSessionManager as MediaManager
 
 # https://stackoverflow.com/questions/65011660/how-can-i-get-the-title-of-the-currently-playing-media-in-windows-10-with-python
 

--- a/bezos.py
+++ b/bezos.py
@@ -9,7 +9,7 @@ import time
 from pypresence import Presence
 import re
 
-from winsdk.windows.media.control import GlobalSystemMediaTransportControlsSessionManager as MediaManager
+from winsdk.windows.media.control import GlobalSystemMediaTransportControlsSessionManager as MediaManager # winrt to winsdk for python 3.10 support
 
 # https://stackoverflow.com/questions/65011660/how-can-i-get-the-title-of-the-currently-playing-media-in-windows-10-with-python
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 asyncio
-winrt
+winsdk
 pypresence
 psutil


### PR DESCRIPTION
Source: https://stackoverflow.com/questions/69610231/why-cant-pip-find-winrt